### PR TITLE
Propose TCP Testing Netlayer

### DIFF
--- a/draft-specifications/Netlayers.md
+++ b/draft-specifications/Netlayers.md
@@ -100,6 +100,22 @@ should be hosted on the port `9045` and using "ED25519-V3" for the key type.
 Upon creation of a hidden service tor provides the "Service-ID", this must be
 supplied as the "designator" in the OCapN Node Locator.
 
+# TCP Testing Netlayer
+
+This is a testing-only, simplistic netlayer, providing no security or anonymity
+whatsovever, and only intended to run tests without huge overhead of setting up
+Tor nodes.
+
+## Implementation
+
+When creating and decoding the OCapN locator, the following information is used:
+
+- **designator**: IPv4 address of a machine. Usually 127.0.0.1 for testing.
+- **transport**: The symbol `tcp`
+- **hints**: Hints are not used, so this may be set to false/omitted.
+
+Only send pure Syrup-encoded messages over the wire.
+
 # Funding
 
 This document has been written with funding through the [NGI Assure Fund](https://nlnet.nl/assure), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) program. Learn more on the [NLnet project page]( https://nlnet.nl/project/SpritelyOCCapN#ack).

--- a/draft-specifications/Netlayers.md
+++ b/draft-specifications/Netlayers.md
@@ -103,7 +103,7 @@ supplied as the "designator" in the OCapN Node Locator.
 # TCP Testing Netlayer
 
 This is a testing-only, simplistic netlayer, providing no security or anonymity
-whatsovever, and only intended to run tests without huge overhead of setting up
+whatsoever, and only intended to run tests without the huge overhead of setting up
 Tor nodes.
 
 ## Implementation

--- a/draft-specifications/Netlayers.md
+++ b/draft-specifications/Netlayers.md
@@ -102,19 +102,26 @@ supplied as the "designator" in the OCapN Node Locator.
 
 # TCP Testing Netlayer
 
-This is a testing-only, simplistic netlayer, providing no security or anonymity
-whatsoever, and only intended to run tests without the huge overhead of setting up
-Tor nodes.
+This is a netlayer designed only for testing purposes. It's designed to be simplistic
+and relatively easy to implement. This comes at the expense of providing no security
+or anonymity whatsoever, and thus must only be used in a testing environment.
 
 ## Implementation
 
-When creating and decoding the OCapN locator, the following information is used:
+The TCP netlayer relies on TCP sockets bound to an IPv4 address and port. The
+implementation should listen and accept all incoming connections to the peer and
+open new outbound connections when required by CapTP.
 
-- **designator**: IPv4 address of a machine. Usually 127.0.0.1 for testing.
-- **transport**: The symbol `tcp`
-- **hints**: Hints are not used, so this may be set to false/omitted.
+The OCapN Locator is as follows:
 
-Only send pure Syrup-encoded messages over the wire.
+- **designator**: A unique string which will identify the peer.
+- **transport**: The symbol `tcp-testing-only`
+- **hints**: The hints are a OCapN Struct with two keys:
+  - **host**: This should a string representation of an IPv4 address to be used to
+reach the peer.
+  - **port**: The port that should be used when connecting to the peer.
+
+All messages are sent encoded with Syrup.
 
 # Funding
 


### PR DESCRIPTION
Born here: https://github.com/ocapn/ocapn-test-suite/pull/4/

As onion netlayer is a bit clunky for quick testing and iteration over implementations, I suggest TCP netlayer — a testing only netlayer. 

@tsyesika 