### PR TITLE
Add note to README that OCapN be fast & easy to implement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ and potentially [Cap'N Proto](https://capnproto.org/) implementations
 can be unified (with significant help and review from the
 [Metamask](https://metamask.io/) team).
 
+The OCapN group has as its goal to have the OCapN specifications be fast and
+easy to implement, ideally not taking a dedicated seasoned developer more than a
+few weeks to implement.
+
 (See also: [this Spritely and Agoric CapTP interop issue](https://github.com/Agoric/agoric-sdk/issues/1827) for some more on current developments.)
 
 ## What do I get from using this?


### PR DESCRIPTION
As discussed in the last (July 2024) OCapN meeting, this adds a note to the README expressing the desire that the specifications are relatively fast and easy to implement (taking ideally no more than a few weeks for a seasoned developer).

Fix #2