### PR TITLE
Rename node (or sometimes machine) to peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You get:
    to their particular program.
 
  - Distributed (acyclic) garbage collection.
-   Nodes can cooperate to inform each other when they no longer need
+   Peers can cooperate to inform each other when they no longer need
    references across the network.
 
  - Network layers supporting live connections (tcp-like), store and

--- a/draft-specifications/CapTP Specification.md
+++ b/draft-specifications/CapTP Specification.md
@@ -62,7 +62,7 @@ OCapN Netlayer specification).
 
 Here's an overview of some things which may occur during a CapTP session:
 
-1. A session is established pairwise between machines.
+1. A session is established pairwise between two peers.
 2. Communication occurs between objects.
     -   Initial connectivity to objects is established by querying the bootstrap
         object for access to known objects (via sturdyrefs or certificates).
@@ -481,7 +481,7 @@ parties MUST send upon a new connection. The operation looks like this:
 ```
 
 It's important that we only have one bidirectional connection between a CapTP
-session. Before trying to connect to a machine, it's important to check that a
+session. Before trying to connect to a peer, it's important to check that a
 connection is not already open before proceeding. There is a race condition
 called the "crossed hellos" problem whereby each side tries to open a new
 connection at the same time and only one of these connection attempts must

--- a/draft-specifications/Locators.md
+++ b/draft-specifications/Locators.md
@@ -11,13 +11,13 @@ Group.
 
 # [Introduction](#introduction)
 
-OCapN Locators used to identify OCapN capable nodes or objects available on a
-specific node. They can be used in band as Syrup encoded data or out of band
+OCapN Locators used to identify OCapN capable peers or objects available on a
+specific peer. They can be used in band as Syrup encoded data or out of band
 when bootstrapping a connection as URIs.
 
-These locators are agnostic to the netlayer that the node or object is located
+These locators are agnostic to the netlayer that the peer or object is located
 on, it encodes the transport  protocol name, key and other additional data which
-would be used by any given  netlayer to reach the node.
+would be used by any given  netlayer to reach the peer.
 
 # Additional Documents
 
@@ -34,13 +34,13 @@ This specification uses the following other specifications:
     Syntax](https://www.rfc-editor.org/rfc/rfc3986): For encoding URI
     representations of locations.
 
-# [Node Locator](#ocapn-node)
+# [peer Locator](#ocapn-peer)
 
-This identifies an OCapN node, not a specific object. This includes enough
+This identifies an OCapN peer, not a specific object. This includes enough
 information to specify which netlayer and provide that netlayer with all of the
-information needed to create a  bidirectional channel to that node.
+information needed to create a  bidirectional channel to that peer.
 
-The node locator include the following pieces of information (more details
+The peer locator include the following pieces of information (more details
 below):
 
 - **Designator**: Usually representing the key, however can be any value
@@ -48,17 +48,17 @@ below):
 - **Transport**: A unique identifier to specify a netlayer
 - **Hints**: A hashmap of additional connection information.
 
-When comparing two node locators, the designator and transport are the only
-pieces of information which need to match. Two node locators can have the same
+When comparing two peer locators, the designator and transport are the only
+pieces of information which need to match. Two peer locators can have the same
 designator and transport but  different hints and be considered to be the same
-node.
+peer.
 
-## [Syrup Serialization](#node-syrup-serialization)
+## [Syrup Serialization](#peer-syrup-serialization)
 
-It's encoded as a record with the label `ocapn-node` and three arguments:
+It's encoded as a record with the label `ocapn-peer` and three arguments:
 
 ```
-<ocapn-node designator  ; string
+<ocapn-peer designator  ; string
             transport   ; symbol (cannot contain ".")
             hints>      ; hashmap | false
 ```
@@ -66,7 +66,7 @@ It's encoded as a record with the label `ocapn-node` and three arguments:
 ### Hints
 
 This is a hashmap of key and values which are designed to encode additional
-connection information that the  netlayer might need to reach the node. The keys
+connection information that the  netlayer might need to reach the peer. The keys
 should be symbols with the values as strings.
 
 There can be any number of hints, including none at all. If no hints are used
@@ -96,14 +96,14 @@ identifier.
 
 # Sturdyref Locator
 
-A sturdyref locator includes a [Node Locator](#node-locator) and
+A sturdyref locator includes a [Pode Locator](#peer-locator) and
 a `swiss-num` which represents a specific object located at that
-node. This should be considered a capability with this information
+peer. This should be considered a capability with this information
 alone being used to obtain a CapTP reference the given object.
 
 The pieces of information encoded in the sturdyref are:
 
-- [Node Locator](#node-locator)
+- [Peer Locator](#peer-locator)
 - Swiss number: string used to obtain an object
 
 ## Syrup Serialization
@@ -111,17 +111,17 @@ The pieces of information encoded in the sturdyref are:
 It's encoded as a record with the label `ocapn-sturdyref` and two arguments:
 
 ```
-<ocapn-sturdyref node swiss-num>
+<ocapn-sturdyref peer swiss-num>
 ```
 
 The arguments are:
 
-- **node**: Syrup record defined in the [Syrup serialization of the Node locator](#node-syrup-serialization)
+- **peer**: Syrup record defined in the [Syrup serialization of the peer locator](#peer-syrup-serialization)
 - **swiss-num**: String which identifies the object.
 
 ## URI Serialization
 
-The URI format follows a similar format to the node URI format, except with a
+The URI format follows a similar format to the peer URI format, except with a
 "/s/" suffix to denoate that it's a sturdyref, followed by the swiss number
 value. Any hints are placed at the end of the URI.
 

--- a/draft-specifications/Netlayers.md
+++ b/draft-specifications/Netlayers.md
@@ -17,7 +17,7 @@ Group.
 # Introduction
 
 OCapN Netlayers are the transport layer which ensures messages are sent and
-delivered to a node. The requirements put upon netlayers is very low and thus it
+delivered to a peer. The requirements put upon netlayers is very low and thus it
 should be flexible enough for new netlayers on a lot of different transport
 protocols. CapTP is designed in such a way that it is agnostic over which
 netlayer it is using and designed in such a way that multiple different
@@ -36,7 +36,7 @@ A netlayer should ensure the following properties are provided:
 Properties that are considered important to the operating principles of OCapN,
 but are not technical requirements for a compliant netlayer, are:
 
-- The reachability of nodes without further configuration by any peer within the
+- The reachability of peers without further configuration by any peer within the
   scope of the network they operate on.
 
 Other properties may be desirable, however not strictly nessesary to comply with
@@ -54,7 +54,7 @@ information required for new implementations to exist and communicate with other
 implementations of that same netlayer provided they operate on the same network.
 
 Other information that must be provided is the information which should be
-encoded within an OCapN node locator, this is:
+encoded within an OCapN peer locator, this is:
 
 - Designator
 - Transport
@@ -95,10 +95,10 @@ service.
 - **transport**: The symbol `onion`
 - **hints**: Hints are not used, so this may be set to false/omitted.
 
-The "hidden service" facility is used to create a CapTP node. The hidden service
+The "hidden service" facility is used to create a CapTP peer. The hidden service
 should be hosted on the port `9045` and using "ED25519-V3" for the key type.
 Upon creation of a hidden service tor provides the "Service-ID", this must be
-supplied as the "designator" in the OCapN Node Locator.
+supplied as the "designator" in the OCapN peer Locator.
 
 # Funding
 


### PR DESCRIPTION
As per our agreement in last month's meeting the machine/vat/node (CapTP capable endpoint) will be named peer.

