### PR TITLE
Fix month name in January 2024 meeting minutes

### DIFF
--- a/meeting-minutes/2024-01-09.md
+++ b/meeting-minutes/2024-01-09.md
@@ -1,4 +1,4 @@
-﻿# December 2024 OCapN pre-standardization meeting, 2024-01-09
+﻿# January 2024 OCapN pre-standardization meeting, 2024-01-09
 
 - **Chair:** Jonathan Rees
 - **Scribe:** Christine Lemmer-Webber


### PR DESCRIPTION
Noticed it said December where it should say January