### PR TITLE
Add Sturdy References to the Model

### DIFF
--- a/draft-specifications/CapTP Specification.md
+++ b/draft-specifications/CapTP Specification.md
@@ -436,9 +436,8 @@ An example of how to use this method is:
             <desc:import-object 5>>  ; object exported by us at position 5 should provide the answer
 ```
 
-> Fetch does not produce [Sturdy References](./Model.md#sturdy-reference).
-> Fetch produces live references, [Targets](./Model.md#target), for which there
-> may exist a corresponding Sturdy Reference or [Locator](./Locators.md).
+> Fetch may produce any [Value](./Model.md#value) in the model and is the
+> the mechanism for creating original [Sturdy References](./Model.md#sturdy-reference).
 > A mechanism for looking up a Locator or Sturdy Reference for a Target returned
 > by `fetch` is optional, implementation-specific, and necessarilly a closely held
 > capability of the OCapN implementation that should not be revealed to guest

--- a/draft-specifications/CapTP Specification.md
+++ b/draft-specifications/CapTP Specification.md
@@ -437,8 +437,8 @@ An example of how to use this method is:
 ```
 
 > Fetch may produce any [Value](./Model.md#value) in the model and is the
-> the mechanism for creating original [Sturdy References](./Model.md#sturdy-reference).
-> A mechanism for looking up a Locator or Sturdy Reference for a Target returned
+> the mechanism for creating original [Sturdyrefs][Model-Sturdyref].
+> A mechanism for looking up a Locator or Sturdyref for a Target returned
 > by `fetch` is optional, implementation-specific, and necessarilly a closely held
 > capability of the OCapN implementation that should not be revealed to guest
 > code by default.
@@ -886,6 +886,28 @@ Party Handoffs](#third-party-handoffs) section.
 <desc:export position>  ; position: positive integer
 ```
 
+## [`ocapn-sturdyref`](#ocapn-sturdyref)
+
+A [Sturdyref][Model-Sturdyref] is a value that represents a passable capability
+to obtain a "live" value from a peer, even if that peer is currently offline.
+
+In a message, a sturdy reference is the serialized form of a [Sturdyref
+Locator][Locator-Sturdyref-Syrup].
+
+```
+<ocapn-sturdyref peer swiss-num>
+```
+
+Where `peer` is the serialized form of a [Peer Locator][Locator-Peer-Syrup].
+
+```
+<ocapn-peer transport   ; symbol (cannot contain ".")
+            designator  ; string
+            hints>      ; struct | false
+```
+
+> Sturdyref locators are the only value descriptor that lacks a `desc:` prefix.
+
 ## [`desc:answer`](#desc-answer)
 
 This is used to refer to a promise which is being pipelined. The position MUST
@@ -1137,4 +1159,7 @@ This document has been written with funding through the [NGI Assure Fund](https:
 [Model-ByteArray]: ./Model.md#bytearray
 [Model-Reference]: ./Model.md#reference-capability
 [Model-Passable]: ./Model.md#value
+[Model-Sturdyref]: ./Model.md#sturdy-reference
 [Locators]: ./Locators.md
+[Locator-Sturdyref-Syrup]: ./Locators.md#sturdyref-syrup
+[Locator-Peer-Syrup]: ./Locators.md#peer-syrup

--- a/draft-specifications/CapTP Specification.md
+++ b/draft-specifications/CapTP Specification.md
@@ -419,11 +419,12 @@ receive both [`op:start-session`](#opstart-session) messages.
 
 ## `fetch` Method
 
-This method is used to fetch an object from the bootstrap object. To use it you
-need a `swiss-number` which is a Binary Data type. This swiss number should
-correspond an object which exists in this session. The result will be the object
-which corresponds to this `swiss-number` or an error if the object does not
-exist or a swiss number was not provided.
+This method is used to fetch a Target object from the bootstrap object.
+To use it you need a `swiss-number` which is a
+[ByteArray](./Model.md#bytearray).
+This swiss number should correspond an object which exists in this session.
+The result will be the object which corresponds to this `swiss-number` or an
+error if the object does not exist or a swiss number was not provided.
 
 An example of how to use this method is:
 
@@ -434,6 +435,16 @@ An example of how to use this method is:
             3                        ; Answer position: positive integer
             <desc:import-object 5>>  ; object exported by us at position 5 should provide the answer
 ```
+
+> Fetch does not produce [Sturdy References](./Model.md#sturdy-reference).
+> Fetch produces live references, [Targets](./Model.md#target), for which there
+> may exist a corresponding Sturdy Reference or [Locator](./Locators.md).
+> A mechanism for looking up a Locator or Sturdy Reference for a Target returned
+> by `fetch` is optional, implementation-specific, and necessarilly a closely held
+> capability of the OCapN implementation that should not be revealed to guest
+> code by default.
+> In E, this capability was called an
+> [Introducer](http://erights.org/elang/concurrency/introducer.html).
 
 ## `deposit-gift` Method
 

--- a/draft-specifications/Locators.md
+++ b/draft-specifications/Locators.md
@@ -34,7 +34,7 @@ This specification uses the following other specifications:
     Syntax](https://www.rfc-editor.org/rfc/rfc3986): For encoding URI
     representations of locations.
 
-# [peer Locator](#ocapn-peer)
+# [Peer Locator](#ocapn-peer)
 
 This identifies an OCapN peer, not a specific object. This includes enough
 information to specify which netlayer and provide that netlayer with all of the
@@ -53,6 +53,7 @@ pieces of information which need to match. Two peer locators can have the same
 designator and transport but  different hints and be considered to be the same
 peer.
 
+<a name="peer-syrup"></a>
 ## [Syrup Serialization](#peer-syrup-serialization)
 
 It's encoded as a record with the label `ocapn-peer` (symbol) and three
@@ -105,6 +106,7 @@ The pieces of information encoded in the sturdyref are:
 - [Peer Locator](#peer-locator)
 - Swiss number: string used to obtain an object
 
+<a name="sturdyref-syrup"></a>
 ## Syrup Serialization
 
 It's encoded as a record with the label `ocapn-sturdyref` and two arguments:

--- a/draft-specifications/Locators.md
+++ b/draft-specifications/Locators.md
@@ -118,6 +118,10 @@ The arguments are:
 - **peer**: Syrup record defined in the [Syrup serialization of the peer locator](#peer-syrup-serialization)
 - **swiss-num**: String which identifies the object.
 
+The Syrup serialization of a Sturdyref locator participates in the
+[Model](./Model.md#sturdy-reference) as the in-band on-the-wire representation
+of a Sturdy Reference.
+
 ## URI Serialization
 
 The URI format follows a similar format to the peer URI format, except with a

--- a/draft-specifications/Model.md
+++ b/draft-specifications/Model.md
@@ -34,7 +34,7 @@ References:
 
 - [Target](#target)
 - [Promise](#promise)
-- [Sturdy References](#sturdy-reference)
+- [Sturdyref](#sturdyref)
 
 # Atom
 
@@ -477,11 +477,11 @@ received promises will satisfy the pass invariants applicable to their type.
 > [Containers](#container) maintain [Pass Invariant
 > Equality](#pass-invariant-equality).
 
-## Sturdy Reference
+## Sturdyref
 
-A Sturdy Reference (Sturdy Ref) represents the capability to attempt to obtain
-a live reference (a Target) for a [Locator](./Locator.md), but encapsulating
-the locator.
+A Sturdyref (sturdy reference) represents the capability to attempt to obtain a
+live reference (a Target) for a [Locator](./Locator.md), but encapsulating the
+locator.
 
 > - **Guile**: to be proposed
 > - **JavaScript**: a JavaScript object with one own property:
@@ -501,36 +501,45 @@ Reference itself.
 
 > Some names for this mechanism are "redeem", "revive", "vivify", or "enliven".
 
-A Sturdy Reference is unlike a Target in that it is transferrable to another
+A Sturdyref is unlike a Target in that it is transferrable to another
 peer, and the destination peer no longer requires a session with the original
-peer to redeem the Sturdy Reference.
-The Sturdy Reference is transferred as data.
+peer to redeem the Sturdyref.
+The Sturdyref is transferred as data.
 
-Although a Sturdy Reference does not keep the encapsulated Locator a secret
+Although a Sturdyref does not keep the encapsulated Locator a secret
 among peers, peers can collude to encapsulate a Locator in a Sturdy Ref and
 hide it from their respective guest programs, while preserving those programs'
-ability to transfer and redeem the Sturdy Reference for a live ref at the
+ability to transfer and redeem the Sturdyref for a live ref at the
 designated Locator.
 
-A Sturdy Reference only encapsulates a Designator, Transport, Swissnum, and
+A Sturdyref only encapsulates a Designator, Transport, Swissnum, and
 Connection Hints.
 A Locator URL might convey other hints, but these are not captured by a Sturdy
-Reference or transferred when a Sturdy Reference passes to another peer.
+Reference or transferred when a Sturdyref passes to another peer.
 
-Sturdy References do not have [Pass Invariant Equality](#pass-invariant-equality).
+Sturdyrefs do not have [Pass Invariant Equality](#pass-invariant-equality).
 A sturdy reference sent from a local peer to a remote peer, then from the
 remote peer back, will not be equal to the original.
 
-> Holding a Sturdy Reference does not implicitly convey the capability to
-> reveal the underlying Locator.
+> Holding a Sturdyref does not implicitly convey the capability to reveal the
+> underlying Locator under the terms of [Distributed Confinement][].
 > Although OCapN CapTP specifies that sturdy references are opaque,
-> transferrable, and redeemable for a live reference, obtaining a Sturdy
-> Reference for a Locator or a Locator from a Sturdy Reference is a closely
-> held implementation-specific protocol, conventionally called an
-> [Introducer](http://erights.org/elang/concurrency/introducer.html),
-> that is beyond the scope of this CapTP specification.
+> transferrable, and redeemable for a live reference, obtaining a Sturdyref for
+> a Locator or a Locator from a Sturdyref may be a closely held
+> implementation-specific protocol, conventionally called an
+> [Introducer](http://erights.org/elang/concurrency/introducer.html), that is
+> beyond the scope of this CapTP specification.
 >
-> Sturdy references and locators are collectively Offline Capabilities.
+> Not all peers are obligated to participate in Distributed Confinement.
+> Distributed Confinement is a cooperative arrangement among some peers to hide
+> sturdyref locators from confined guest programs but enable those guest
+> programs to pass sturdyrefs among themselves, regardless of whether the
+> referrent peer is online.
+> The locators are transparent to the peers, who can simply read them off the
+> wire protocol.
+> So, sturdyrefs provide a very specific and limited kind of secrecy.
+>
+> Sturdyrefs and locators are collectively Offline Capabilities.
 
 # Error
 
@@ -643,3 +652,5 @@ OCapN holds invariant that:
 >
 > OCapN does not hold invariant the preservation of arbitrary JSON texts
 > through arbitrary JSON implementations in arbitrary languages.
+
+[Distributed Confinement]: http://www.erights.org/elib/capability/dist-confine.html

--- a/draft-specifications/Model.md
+++ b/draft-specifications/Model.md
@@ -34,6 +34,7 @@ References:
 
 - [Target](#target)
 - [Promise](#promise)
+- [Sturdy References](#sturdy-reference)
 
 # Atom
 
@@ -432,6 +433,11 @@ A target might be sent from a local peer to a remote peer, then the remote peer
 may send that target back to the local peer.
 The sent target will be equal to the received target and no other value.
 
+> Target is synonymous with Object Capability, Ocap, Live Reference, Online
+> Capability, and Permission.
+> Authority is what one can accomplish with the permissions they hold and
+> may exceed the sum of the permissions.
+
 ## Promise
 
 A Promise represents the eventual return value (fulfillment) or thrown error
@@ -470,6 +476,61 @@ received promises will satisfy the pass invariants applicable to their type.
 > that is a Struct, the sent and received structs will be equal, because all
 > [Containers](#container) maintain [Pass Invariant
 > Equality](#pass-invariant-equality).
+
+## Sturdy Reference
+
+A Sturdy Reference (Sturdy Ref) represents the capability to attempt to obtain
+a live reference (a Target) for a [Locator](./Locator.md), but encapsulating
+the locator.
+
+> - **Guile**: to be proposed
+> - **JavaScript**: a JavaScript object with one own property:
+>   for the registered symbol key `passStyle`, the value is the string `sturdyRef`.
+>   The object is otherwise entirely opaque.
+>   ```js
+>   ({ [Symbol.for('passStyle')]: 'sturdyRef' })
+>   ```
+> - **Python**: to be proposed
+
+OCapN implementations must provide a mechanism that produces a Promise
+for a Target from the encapsulated Locator, by attempting to establish
+a session with the designated Peer and Fetching the designated Swissnum.
+The mechanism should not be closely held.
+That is, the mechanism should require no special capability beyond the Sturdy
+Reference itself.
+
+> Some names for this mechanism are "redeem", "revive", "vivify", or "enliven".
+
+A Sturdy Reference is unlike a Target in that it is transferrable to another
+peer, and the destination peer no longer requires a session with the original
+peer to redeem the Sturdy Reference.
+The Sturdy Reference is transferred as data.
+
+Although a Sturdy Reference does not keep the encapsulated Locator a secret
+among peers, peers can collude to encapsulate a Locator in a Sturdy Ref and
+hide it from their respective guest programs, while preserving those programs'
+ability to transfer and redeem the Sturdy Reference for a live ref at the
+designated Locator.
+
+A Sturdy Reference only encapsulates a Designator, Transport, Swissnum, and
+Connection Hints.
+A Locator URL might convey other hints, but these are not captured by a Sturdy
+Reference or transferred when a Sturdy Reference passes to another peer.
+
+Sturdy References do not have [Pass Invariant Equality](#pass-invariant-equality).
+A sturdy reference sent from a local peer to a remote peer, then from the
+remote peer back, will not be equal to the original.
+
+> Holding a Sturdy Reference does not implicitly convey the capability to
+> reveal the underlying Locator.
+> Although OCapN CapTP specifies that sturdy references are opaque,
+> transferrable, and redeemable for a live reference, obtaining a Sturdy
+> Reference for a Locator or a Locator from a Sturdy Reference is a closely
+> held implementation-specific protocol, conventionally called an
+> [Introducer](http://erights.org/elang/concurrency/introducer.html),
+> that is beyond the scope of this CapTP specification.
+>
+> Sturdy references and locators are collectively Offline Capabilities.
 
 # Error
 


### PR DESCRIPTION
I mistakenly omitted Sturdy Reference from the OCapN data model. This change adds them, clarifies their role and semantics, and explicitly calls out the role of a sturdyref locator as the in-band representation of a sturdyref.