### PR TITLE
Spec Bug: deposit-gift should specify an export (not an import)

### DIFF
--- a/draft-specifications/CapTP Specification.md
+++ b/draft-specifications/CapTP Specification.md
@@ -452,7 +452,7 @@ Here is an example of how to use this method:
 <op:deliver-only <desc:export 0>            ; Remote bootstrap object
                  ['deposit-gift             ; Argument 1: Symbol "deposit-gift"
                   gift-id                   ; Argument 2: Non-negative integer (>=0)
-                  <desc:import-object 5>]>  ; Argument 3: object being shared via handoff
+                  <desc:export 5>]>         ; Argument 3: object being shared via handoff
 ```
 
 ## `withdraw-gift` Method


### PR DESCRIPTION
"export" here means an object hosted by the receiver of the message. With this message we're asking this exporter to mark their export as a gift.

noted here https://github.com/ocapn/ocapn/issues/242