### PR TITLE
Tentative Syrup representation of Tagged

### DIFF
--- a/draft-specifications/CapTP Specification.md
+++ b/draft-specifications/CapTP Specification.md
@@ -876,6 +876,22 @@ Party Handoffs](#third-party-handoffs) section.
 <desc:export position>  ; position: positive integer
 ```
 
+## [`desc:tag`](#desc-tag)
+
+A [Tagged](Model-Tagged) Value is a point of extensibility for the data model
+that allow for discriminated unions of user-defined types.
+These appear in-band as `desc:tag`
+
+```
+<desc:tag
+  label   ; String
+  value   ; Value
+>
+```
+
+[`op:untag`](#opuntag) can assert that a referrent has a particular `label`
+and pipeline a message to the underlying `value`.
+
 ## [`desc:answer`](#desc-answer)
 
 This is used to refer to a promise which is being pipelined. The position MUST
@@ -1127,4 +1143,5 @@ This document has been written with funding through the [NGI Assure Fund](https:
 [Model-ByteArray]: ./Model.md#bytearray
 [Model-Reference]: ./Model.md#reference-capability
 [Model-Passable]: ./Model.md#value
+[Model-Tagged]: ./Model.md#tagged
 [Locators]: ./Locators.md


### PR DESCRIPTION
Closes #246 

The specification currently lacks a (tentative) Syrup representation of Tagged. This clarifies that a Tagged is not merely a Syrup Record, but a particular record that can be differentiated from other descriptors. This clarifies that `op:untag` does not, for example, pipeline through arbitrary records.

We do not have consensus on Syrup in general, but having *something* is necessary for prototype implementers to converge on the same semantics.