### PR TITLE
March 2026 minutes: Improve formatting for viewing as markdown

### DIFF
--- a/meeting-minutes/2026-03-10.md
+++ b/meeting-minutes/2026-03-10.md
@@ -14,14 +14,14 @@
 
 To update the agenda I will edit this comment (first in issue) in github.  As usual, suggestions and desires in this issue's comments.
 
-**Date/time**: 2nd Tuesday [19:00 UTC on 10 March 2026](https://www.timeanddate.com/worldclock/converter.html?iso=20260310T190000&p1=239&p2=1440&p3=43&p4=1240)
-**Location**: https://bbb.sfconservancy.org/b/chr-pm5-cl8-ctl  - test link ahead of time
-**Scribe**: Ridley + Christine
-**Previous meeting's minutes**: [here](https://github.com/ocapn/ocapn/pull/256/changes)
-**Draft agenda**:
+* **Date/time**: 2nd Tuesday [19:00 UTC on 10 March 2026](https://www.timeanddate.com/worldclock/converter.html?iso=20260310T190000&p1=239&p2=1440&p3=43&p4=1240)
+* **Location**: https://bbb.sfconservancy.org/b/chr-pm5-cl8-ctl  - test link ahead of time
+* **Scribe**: Ridley + Christine
+* **Previous meeting's minutes**: [here](https://github.com/ocapn/ocapn/pull/256/changes)
+* **Draft agenda**:
 
 - Pick a scribe.  
-- Approve February minutes #256 
+- Approve February minutes [#256](https://github.com/ocapn/ocapn/pull/256/changes)
 - Approve today's agenda
 
 **Old business**
@@ -41,45 +41,76 @@ Topics suggested by Ridley and Jessica for next plenary meeting:
 
 Kumavis will scribe.
 
-https://github.com/ocapn/ocapn/pull/252
-Ridley: Prev there was a flag on the op:listen for a partial subscription. In practice it meant too many notifications you didnt need. So theres two modes of operations, notification just for resolution or notification for promise shortcutting across remote peers.
+## Change op:listen to have one mode of operation [#252](https://github.com/ocapn/ocapn/pull/252)
+
+Ridley: Previously there was a flag on the op:listen for a partial subscription. In practice it meant too many notifications you didnt need. So theres two modes of operations, notification just for resolution or notification for promise shortcutting across remote peers.
+
 Ridley: need to fix some conflicts in PR
+
 JAR: objections to merge? (none)
 
-https://github.com/ocapn/ocapn/issues/258
-Jessia: In Captp specification, the gift on the exporter. In the test suite its assumed to be a ByteArray. 
+## Should desc:handoff-give's gift-id be a bytearray or integer [#258](https://github.com/ocapn/ocapn/issues/258)
+
+Jessica: In Captp specification, the gift on the exporter. In the test suite its assumed to be a ByteArray. 
 CLM: The design that I endud up settling on was-- I forgot what I settled on but there was a security concern. Theres an info leak on how many handoffs if you use an incrementing integer.
+
 Baldur: Each session has its own namespace (for gift id), yes? How Captp of E did it was you had two levels deep of tables. [...] The only thing you need to do is designate between the gifts.
+
 Kriskowal:
+
 CLM: We currently use ByteArray, we could possibly use incremented integers as Baldur suggests. [...] The current specification avoids the "who" of the operation, and making this change would require adding in more "who".
+
 Kriskowal: 
+
 CLM: [...] I'll just say for now the subtable approach may work. [...] But is there any motivating reason to use a subtable?
+
 Kriskowal: Namespace should be randomized.
+
 Jessica: I'd assume when giftId continues to be an incrementing integer, the [gifter] and the exporter. I'm fine with the ByteArray as well.
+
 Baldur: [...] The only requirement is that you can use the giftId as a key to lookup in a hash table.
+
 CLM: There's a compelling reason to not do integers. I haven't heard an argument for not doing random ByteArrays. If someone comes up with a reason in the future, lets re-examine it.
+
 David: Someone should make a change to the spec.
+
 JAR: 32 bytes?
+
 David: yes
+
 JAR: Resolved.
 
-Hello Josh Corbin
+Hello Josh Corbin.
 kriskowal: Josh will be working with us for the next couple weeks and so I invited Josh to join.
 
-https://github.com/ocapn/ocapn/issues/236
+## Resolver target objects or message operations [#236](https://github.com/ocapn/ocapn/issues/236)
+
 Jessica: We were talking about getting rid off the extra gc messages
+
 CLM: we were considering changing Resolvers in a way so that they can be automatically GC'd on resolution. If you do the op for fulfilling or breaking a promise, you can implicitly collect the resolver, allowing us to no longer explicitly fire a gc message for the resolver
+
 JAR: issue has a long thread that ends with Ridley being confused.
+
 kriskowal: Its irreducible that these functions exist and can be passed. In the javascript implementation a function can not be mistaken for an actor.
+
 CLM: This is not an issue in Goblins, afaik, well Jessica says maybe for op:listen, it would be possible if you had a more manual implementation of ocapn. This is not an issue for us. If you took the test suite python implementation and drive that manually, and so you could pass along this resolver. [...]
+
 kriskowal: we should not bake into the protocol that there is a schema for a target that has the resolver protocol on it.
+
 CLM: so this is academic, we have three implementations that dont expose the resolver. I'm mostly worried about it bc i want this to be useable by an implementation that does not take this assumption. but these imaginary implementations are not here.
+
 Jessica: I think we should back up, the issue covers two separate issues. Wouldnt it be nice to reduce some of these gc messages for the most common use cases. Theres another issue of [...] the resolver based way or the operation way. I think we can do one or another. There's a resolver reference appearing in op:deliver and op:listen. I don't know wether we leak resolvers and promises, we're not as careful as we maybe need to be if we add this note to the specification.
+
 CLM: Jessica is right, theres 2 separate issues here. 1) implicit gc for resolvers, 2) specify resolver api. I think we should not talk about #2 to limit scope, but we need to talk about it bc if we have these special operators that autogc, you can't proxy these methods. Either have these special operations that have this built in gc operation, OR you can have a more general purpose API but then we dont get the free no-gc mechanism.
+
 Jessica: I don't think its take these operators and get the GC benefits... I propose that we split, based on this one discussion should we introduce two new operators (op:fulfill/break), I'm advocating that we split these two issues. Do we use the new operators, and do we have some implicit gc operation.
+
 kriskowal: the model contains no reification of resolvers. they are Target like, unum like, they dont move around, they stay on the host that created them. at this layer of the specification, I would perfer Resolver not be confused for a Target. to Jessica's point that Resolvers are fundamental to the protocol, then theres another thing in the data model that should be the representation in the data model. my motivation is not reducing GC, but that its confusing that we're using a descriptor for something that is not passible.
+
 Ridley: If i want to listen to a promise that i get in an op:deliver i can listen to that the same as a promise i get (another way). I am hesitant to have two separate interfaces for promises and resolvers. Similar to the bootstrap obj, this is the only place we define an interface. As i was looking at having different kinds of resolvers for internal and external things, it felt weird. if there was an internal resolver i might send op:fulfil, for an external i might send op:deliver symbol.resolve or something. this felt weird to me.
+
 kriskowal (chat): first and second class resolvers.
+
 JAR: time, to be continued in the implementers call.
 
 


### PR DESCRIPTION
Updated meeting minutes for the March 10, 2026 meeting, mainly to add blank lines to make the file easier on the eyes.