### PR TITLE
Add meeting minutes for OCapN on 2026-09-08

### DIFF
--- a/meeting-minutes/2026-09-08.md
+++ b/meeting-minutes/2026-09-08.md
@@ -1,0 +1,155 @@
+# OCapN 2026-09-08
+
+https://github.com/ocapn/ocapn/issues/285
+
+**Date/time**: 2nd Tuesday [19:00 UTC on 8 September 2026](https://www.timeanddate.com/worldclock/converter.html?iso=202600908T190000&p1=239&p2=1440&p3=43&p4=1240)
+
+# Attendees
+
+- Baldur (independent)
+- Mark Miller (Endo)
+- Jessica Tallon (Spritely)
+- Kris Kowal (Endo)
+- David Thompson (Spritely)
+- Jonathan A Rees (Chair, independent)
+- Ridley (Independent)
+
+Scribe: Kris Kowal
+
+# Agenda
+
+- [Error type and passage invariants #142](https://github.com/ocapn/ocapn/issues/142) - report from @erights
+- [Move crypto-version from public key and signature to op:start-session #288](https://github.com/ocapn/ocapn/pull/288) - approve? (needs Agoric review?)
+- [OCapN encoding #284](https://github.com/ocapn/ocapn/pull/284) - encoding implications
+
+# Minutes
+
+(MarkM says will present second)
+
+JAR: Second on the agenda. We have a couple short items. The agenda comes from Ridley and I appreciate that. I will just start with this one while we wait for Mark. Topic is #288, moving crypto to start session. Do we have a champion? Ridley opened, Jessica discussed.
+
+## Moving crypto to start session #288
+
+Ridley: I can talk about it. Someone else is welcome to.
+
+JAR: Jessica has reviewed this, maybe Kris has not. This is a PR. What needs to be done to get approval on this.
+
+Ridley: We have not technically agreed on this at plenary. We used to use S-expressions that doesn’t make sense in our protocol and it has been on the list of things to fix. Then we realized that we might not need to send it for every [] we agreed that it would be simpler to send a Crypto Version when establishing a session. We simplify some data structures.
+
+Christine: I think the other aspect of this conversation is whether or not to, what the structure of (the crypto) should be. We can use really simple byte arrays because we know about the protocol (version) declaration what the shape of the structure should be.
+
+Ridley: Yes
+
+JAR: Is there any dissent or other questions. I wonder whether Kris wants to review this or if it can just be merged.
+
+Kris: In my role as editor I would like to do a copyedit pass, but do not believe it is controvercial from a state of consensus, and move that we formally declare it accepted from consensus and I'll do a copyedit pass
+
+JAR: I sense consensus as well. There is no assignee so I will assign it to you. Right?
+
+Jessica: I approved it. I did have a comment about mentioning both the hashing and key generation. Ridley has already addressed it.
+
+JAR: So are we done here?
+
+Chorus: Yes.
+
+## OCapN encoding #284
+
+JAR: There is a discussion of encoding implications on 284. This was opened by Ridley. This is a PR. We talked about… This PR is from the implementers group. There are many comments that seem editorial.
+
+Ridley: We made some decent progress on this at implementer meetings. There remain some pieces in our milestone list. About half of them have encoding implications. The error topic, for example. So, I have a list at the top of the PR that need to be crossed off before we agree upon a complete encoding. I am not bringing any specific items. That list has five items on it. And we are making good progress on it. We agreed on the first one. I will bring up that PR 277 for promise shortening is still awaiting review.
+
+JAR: Yeah. I think we should wait for the implementer group to prepare this for the implementer group.
+
+Ridley: I think that is a good goal.
+
+JAR: For 277, Kris and Mark are assigned for review. So, can I get assurance of a review for 277.
+
+Kris: I will do a copy edit but need Mark to do a semantic review.
+
+JAR: So, we will leave this on the table for now.
+
+## Interlude
+
+JAR: The only other thing I’ve had on the agenda is to review what is going on at the imlpementer call. Ridley, should I put some of these on the agenda for the group meeting? I am looking at your report from the implementers group. "We would like input from others on the path forward".
+
+Ridley: We discussed the first. We made some good progress on the second. We have a better undrestanding of where people are coming from but have not come to consensus. The third one has led to some interesting conversation which Richard graciously accepted to write-up, but is on vacation, so we will wait.
+
+JAR: My reaction to the list is that you have been doing a good job of creating an agenda for us so I will leave these things here. Okay, with that, we are ready to go with Mark's presentation.
+
+## Errors #142
+
+MarkM: (logistics) So, this a PR (#289) … Also, apologies for how late this is. It should have been done a week ago but completed yesterday and understandable that it's not been reviewed. I will begin with the summary. Errors will be split between hidden and revealed information, to enable separate access control for the hidden information. Particularly, the call stack should not be visible to anyone who holds the error. It should be logged and there needs to be a separate access control for reaching the hidden information, because a stack can and has been used to attack. My experience starts with the Darpa review, where Dean Tribble and David Wagner were able to find information the other party was trying to encapsulate. This level of the OCapN spec is only concerned with revealed information as only that passes over the wire. The error is like a struct. The values cannot contain capabilities. ... SturdyRefs may or may not be a capability. The field values can contain errors or data that contains errors. Errors themselves cannot be compared for equality. That's the overview from the application programmer's perspective. So, let me first ask questions about that before going into details.
+
+Chorus: *crickets*
+
+MarkM: I won't read the definitions. They are for passables, capabilities enable the sense or cause of effects so target, promise, and sturdy ref. We previously talked about pass invariance. (formal definition of pass invariance follows). I define an identity to be preciese about this, errors do not have comparable identities. And now, a throwable is a passable devoid of capabilities. I specified a broken promise can only be broken by a throwable. This raises an interesting question, since promises can be broken after they are created, what happens if there's an attempt to break a promise with a non-throwable? I don't think we can specify ... my decision is the promise still gets broken, but the broken promise of a language level, unfortunately the reason is not throwable. We should preserve that it is broken, but break with an unspecified throwable.
+
+Errors, what is revealed, this is where we get to the four reserved names, "stack": so any langauge can populate the local language stack field without worrying about collision with the stack field name arriving over OCapN. That one would be hell to not do, there is a way to not do it, the Hilbert Hotel, either an underbar stack. My experience with Hilbert Hoteling namespaces is that it is a bug farm. If you get it wrong, it usually works, and you need to understand which namespace you are in. The same for "constructor", unlike "stack", is particular to JavaScript. ... "message" and "name" are particular to JavaScript but the only constraint for them is that they must be a string if present. ... But, the section on non-reserved names also discusses how JavaScript plans to use these, with trouble that is not insurmountable, "message" and "name" could move into this list at the price that JavaScript would have to deal with non-stream message and name. Right now, if I don't get push-back, my sense is that these would not be significant pain to put on the reserved list. I reiterate that my understanding is that the OCapN policy for consideration of language concessions, and I mention that OCapN has several such trade-offs. ... So, the non-reserved names there is no non- (sic) normative spec of how they would be used. I describe the round-tripping requirement and what it imposes upon this. What the fields are of an error and what the values are must round-trip. All of the revealed information of an error must round-trip. And then, there is a long discussion, as I say here, this document does not specify what is hidden. ... Not just the hidden spec and recommendations about redaction and unredaction of text in message, I suggest what all the hidden information would need to be to do a full reconstruction of Causeway, revealing hidden information in logs, and the access control is consistent with the way Causeway was built. Causeway does not assume it can gather all the logs of the causal graph, gathers what logs it can and reconstricuts a partial causal graph. The horizon of the causal graph is either devices or logs it lacked access to. And, also, by the way, the other information not specific to errors that Causeway needs to log, that's basically message sending, whether it results in an error or not, Causeway ideally sees these edges, and promise resolution. I go into some efficiency considerations that would result in less than ideal logging and how to cope with that. That is it! Ready for questions.
+
+Baldur: So, you said that errors are not **comparable**. They are basically like. I was thinking that they are basically like transparent (selfless?) data.
+
+MarkM: Yes, kind of. There's. Certainly because all the information in an error must round-trip, if you compare the contents... what you can't tell is whether they are the same error. If they are the same error, they are associated with the same hidden information. Without the same information, you cannot tell whether two errors are the same passing (passage) of the same error. Nodding to Kris Kowal, if you have received a remote error, what is your request you want to look up? If you provide the contents or hash of the error contents, they might be two different errors with the same stack. Error contents are not a good key for asking your counter-party for hidden information. What Kris came up with is that each direction of each session count the errors as they go by. A direction of session and error count is the index or key that you would use to look up the hidden information. Because it is encoded this way, the OCapN spec does not need to say anything about hidden information. The beautiful thing about it is that Caseway needs the same kind of logging for message sends. Message sends do not have an ID so you could track and connect across the distributed system. With Kris's representation, OCapN doesn't need to do anything. The implementation can track the number for a message.
+
+Baldur: The cause of an error can be another error.
+
+MarkM: Here's a conflict of principles for which I decided to do what Endo already does, which is the fields that are specified as a normal part of the error public API for which there's no necessary a privacy break, an error only has a cause if it has been explicitly put there by user code. It does not have an implicit cause the way we have a stack. The JavaScript property, the field, named "cause" is only ever put there explicitly. All of these that I mentioned ... are explicitly public API of JavaScript, ... without any further access control would be surprising and jarring. So, the other thing I did not mention that I should mention is that Endo provides a good API for creating errors that fit with all of this access control, particularly redaction of the message string, including the full message string in the hidden information, that same Endo API provides another facility for annotation, adding hidden information on a per-error basis. If and therefore we do, we want to explore the cause of an error for diagnostic purposes, so we don't use the cause field and the result is that there's no non-uniformity between the sending and receiving site. If at the originating site, you annotate and it isn't the cause property and you cannot recover the note without a closely held interface. The revelation of that information with inter-peer access control makes a consistent picture. So, we often use the annotations for the cause we care about, especially if it is not suitable for public revelation.
+
+JAR: Uh, huh. Christine.
+
+Christine: Thank you for this proposal. It is very helpful because we haven't discussed about errors and their structure. A shared goal we eventually are interested in implementing debugging. We have not yet had structure or shape of errors. This is the first concrete picture of what that might be. I appreciate the thought and depth and historical perspective you bring to it. As we have said already we have only had a little time to review. Initial feedback we had at Spritely's morning meeting is that we think it would be useful to separate this into two conversations, maybe three, it is often useful to separate into iterable pieces. Structurally, there is strong overlap when we get to distributed debugger. There are some pieces we haven't done a review, so we haven't compared to Scheme and other languages. We don't have enought time to say whether we like this exact structure. I don't want that conversation yet. The parts are (second) whether or not, can a throwable pass capabilities. We want to be very cautious about capabilities passing the barrier but the question whether they can be passed is I think the part two and I think the part (maybe only two). Let me respond separately. Regarding structure, having a particular structure achieve a consensus between JS and Scheme, errors tend to have very particular needs across languages. What makes sense to JS+Scheme makes sensse, we don't know about Rust. So, I am a little uncertain whether we are being premature by specifying the particular structure or move into convention we don't address at this particular layer. Having the tagged record we might be able to work on them. The second is whether to pass capabilities and you have brought up several interesting ways like a separate table with an index. There is some interest in the Spritely side, in the category of Causeway capbability debuggers, the properties of that, we mentioned previously explored this idea and using sealers and unsealers that you might have sealed exceptions that would not be compatible in this direction. This might be useful because we could use existing debugger facilities.
+
+MarkM: You're already over my limit for questions I can remember to answer.
+
+Christine: We already have a counter proposal. Let's get into your responses.
+
+MarkM: So, let me start with the sealer and unsealer. So, there are two ways in a CapTP like protocol to implement sealers and unsealers that go back to the E days. And, they are that if you implement it straight-forwardly then the sealer and unsealer and the unsealed box are just targets at the same peer and when you want to, and if you have a sealed box remotely, what you have is a reference to the actual sealed box at the peer of origin. If you want to unseal it you send the reference to the box to unseal it. So, it doesn't skip the need to send a message. And, then, what you're adding, if you're only sealing the hidden information, which I think needs to be the case, then the addition of the sealed box in what is send and requiring a message to the unsealer is just extra baggage in the protocol compared to Kris Kowal's counting primitive. The beauty of the trick is not just that it makes the transmitted data ... we don't need agreement on the shape of that data and it only comes up when we ask how to access the information.
+
+Christine: I will note also that my goal was not to provide that exact counter-proposal, but to explain why we are not ready to agree that we don't have capabilities. We agree we need the safety aspect of. We have only three minutes left so we won't get through all of this no matter what.
+
+MarkM: Have the notes captured your questions?
+
+Christine: Here's my short bullet version
+
+1. We would like to separate the conversation of particular structure and whether we should have a particular structure from whether or not we can pass capabilities, so we can have those conversations separately.
+
+MarkM: I understand the question about capabilities but not particular structure. What does it look like to not have particular structure.
+
+Christine: Let me get to the counter-proposal that I do not expect we can go through. No restrictions of what is throwable and strong advice about the dangers of including capabilities at the border. We spend the long-term approach, we move to deciding the structure of this OCapN group. I would say in terms of how to deal with details, the biggest part is we do the separation between the structure and capabilities parts. So let me give a comically absurd version of things in terms of a structure that someone would want to send over the wire. Suppose we had sandboxed Brainfuck program we wanted to evaluate. That would be a completely different structure that Brainfuck interpreters would even consider. I am not proposing we have a Brainfuck implementation. I am saying there could be ...
+
+MarkM: I appreciate the attempt but I didn't understand the example.
+
+Christine: There might be exceptional structures we won't be able to get to in this group.
+
+MarkM: Whatever we allow I think we have to maintain the round-tripping constraint such that if language A is talking to a peer of language B is talking to a peer of language C, if A sends an error through B to another A that this pathway is without loss.
+
+Christine: I think round-trippability is a great goal but isn't broken ...
+
+MarkM: So one thing I am concerned about off-the-bad I have no idea zero idea about an arbitrary language. Let's take a hypothetical, if it wants to include in errors something is that some other endpoint cannot represent in its errors, then that would, that means sending an error through an intermediary would lose information and violate round-tripping. We have to find, we have to pin something everyone can agree to preserve all the information whether...
+
+Dave: What makes promises different than erorrs in this regard. We have other values that do not round-trip. (low confidence scribe caught this correctly)
+
+MarkM: This goes back to. Most endpoints, most language bindings will internally have synchronous calls in a turn and synchronously thrown errors. At the boundary all that shows up in OCapN is... OCapN has no synchronous throw. Going back to E, human beings doing code review, cannot be vigilant enough to remember that something it calls might at any time throw an error to be caught by something that called it. So, E went all the way that the entire error is sealed. All you know at a throw is that something bad happened. And, you need to unseal the error for any further information. Over here, because of the nature of JavaScript and I expect other languages (E was green field) is that there are already error objects with public information, but the current usage (and JavaScript certainly allows throw errors to contain capabilities) the common usage pattern is that they do not contain capabilities. In Endo we prevent the passage of capabilities in thrown errors, even locally, because if you forget to think of the error throwing pathway as a communication pathway, you are only conveying information and not capabilities. That can be dangerous but not as dangerous. We further split the revealed and the hidden part with library affordances for trying to think through what you want to reveal and what you want to hide. That's for the author of the error to decide on. It is not up to the intermediary to decide upon. This is in the balance of concerns what I have arrived at in Endo, which we have been living with for a long time and found it practical.
+
+JAR: We're ten minutes over. I think this is a good discussion but we can continue it next month or is there anything that has to be now?
+
+Dave: I think this is a good topic for the implementers meeting and a lot to work out.
+
+Christine: Thank you for writing what you have. Despite what I have written, getting to write a counter-proposal, which does agree with the level of caution, we have a specific way to deal with that. Your concern that developers won't get this right is something we share.
+
+MarkM: I cannot generally attend the implementer calls, because they are about implementation. Am I getting that wrong?
+
+Christine: That is generally correct. I should write up what we discussed in Spritely. We can work out what we can do from there. That's the next immediate step.
+
+MarkM: Okay.
+
+JAR: Okay, right. Yes, and uh, discussion on the issue welcome. I don't know about the division between the PR and the issue, but I guess if you have comments on the details put them on the PR otherwise we have an issue for errors, I believe.
+
+MarkM: #142 is the issue this claims to close.
+
+JAR: I encourage discussion on issues and PRs. I amid commenting on our issue of the milestone. I will try to pay attention to where that stands. I think we're done for today. Any objections to adjourning?
+
+Chorus: no.
+
+Christine: Thanks Jonathan, Mark, and Kris.
+
+Jessica: Thanks everyone.


### PR DESCRIPTION
Documented meeting minutes for the OCapN meeting held on September 8, 2026, including attendees, agenda items, and discussions on various topics such as error handling and encoding implications.